### PR TITLE
feat: support providing host/id config as `.env` variables

### DIFF
--- a/internal/debug.ts
+++ b/internal/debug.ts
@@ -18,16 +18,14 @@ const warnings: Record<ErrorId, ErrorObj> = {
   'err-collect': { level: 'error', text: 'Uh... Something went wrong and I have no clue.' },
 };
 
-function screamer(id: ErrorId, raw?: any) {
-  const { level, text } = warnings[id];
-  // eslint-disable-next-line no-console
-  console[level](`[UMAMI]: ${text}`, '\n');
-  // eslint-disable-next-line no-console
-  raw && (console[level](raw));
-}
-
-function silencio(id: ErrorId, raw?: any) {}
-
-const helloDebugger = process.env.NODE_ENV === 'production' ? silencio : screamer;
+const helloDebugger = process.env.NODE_ENV === 'production'
+  ? (id: ErrorId, raw?: any) => {}
+  : (id: ErrorId, raw?: any) => {
+      const { level, text } = warnings[id];
+      // eslint-disable-next-line no-console
+      console[level](`[UMAMI]: ${text}`, '\n');
+      // eslint-disable-next-line no-console
+      raw && (console[level](raw));
+    };
 
 export { helloDebugger };

--- a/internal/types.ts
+++ b/internal/types.ts
@@ -23,14 +23,6 @@ type PartialPayload = Omit<BasicPayload, 'website'>;
 type PayloadType = 'pageview' | 'event';
 type PreflightResult = 'ssr' | 'id' | 'host' | 'domain' | 'dnt' | 'local' | true;
 
-interface PreflightArgs {
-  ignoreDnt?: boolean
-  domains?: string
-  id?: string
-  host?: string
-  ignoreLocal?: boolean
-}
-
 interface ServerPayload {
   type: PayloadType
   payload: ViewPayload | EventPayload
@@ -49,7 +41,6 @@ export {
   ViewPayload,
   PayloadType,
   ServerPayload,
-  PreflightArgs,
   PreflightResult,
   GetPayloadReturn,
 };

--- a/internal/utils.ts
+++ b/internal/utils.ts
@@ -10,8 +10,6 @@ function isValidString(str: unknown): str is string {
   return typeof str === 'string' && str.trim() !== '';
 }
 
-function assert(value: unknown): asserts value {}
-
 function isInvalidHost(host: unknown): host is string {
   try {
     if (typeof host !== 'string') {
@@ -36,7 +34,7 @@ const umConfig = computed(() => {
       ignoreLocalhost: ignoreLocal = false,
       autoTrack = true,
       version = 1,
-    },
+    } = {},
   } = useAppConfig();
 
   return {
@@ -142,4 +140,4 @@ async function collect(load: ServerPayload) {
     });
 }
 
-export { preflight, getPayload, assert, collect, umConfig };
+export { preflight, getPayload, collect, umConfig };

--- a/internal/utils.ts
+++ b/internal/utils.ts
@@ -94,8 +94,28 @@ function getPayload(): GetPayloadReturn {
   };
 }
 
+function getConfig() {
+  const {
+    umami: {
+      host = '',
+      id = '',
+      domains = '',
+      ignoreDnt = true,
+      ignoreLocalhost: ignoreLocal = false,
+      autoTrack = true,
+      version = 1,
+    },
+  } = useAppConfig();
+
+  // experiment
+  const { public: { umamiHost, umamiId } } = useRuntimeConfig();
+  console.info({ umamiHost, umamiId });
+
+  return { host, id, domains, ignoreDnt, ignoreLocal, autoTrack, version };
+}
+
 async function collect(load: ServerPayload) {
-  const { umami: { host, version } } = useAppConfig();
+  const { host, version } = getConfig();
   const root = new URL(host);
   const branch = version === 2 ? 'api/send' : 'api/collect';
   const endpoint = `${root.protocol}//${root.host}/${branch}`;
@@ -117,4 +137,4 @@ async function collect(load: ServerPayload) {
     });
 }
 
-export { preflight, getPayload, assert, collect };
+export { preflight, getPayload, assert, collect, getConfig };

--- a/middleware/umami.global.ts
+++ b/middleware/umami.global.ts
@@ -1,7 +1,8 @@
+import { getConfig } from '../internal/utils';
 import { umTrackView } from '../utils/umami';
 
 export default defineNuxtRouteMiddleware((to) => {
-  const { umami: { autoTrack } = {} } = useAppConfig();
+  const { autoTrack } = getConfig();
 
   if (autoTrack) {
     umTrackView(to.fullPath);

--- a/middleware/umami.global.ts
+++ b/middleware/umami.global.ts
@@ -1,8 +1,8 @@
-import { getConfig } from '../internal/utils';
+import { umConfig } from '../internal/utils';
 import { umTrackView } from '../utils/umami';
 
 export default defineNuxtRouteMiddleware((to) => {
-  const { autoTrack } = getConfig();
+  const { autoTrack } = umConfig.value;
 
   if (autoTrack) {
     umTrackView(to.fullPath);

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -10,6 +10,12 @@ export default defineNuxtConfig({
       version: 1,
     },
   },
+  runtimeConfig: {
+    public: {
+      umamiHost: '',
+      umamiId: '',
+    },
+  },
 });
 
 declare module '@nuxt/schema' {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-umami",
   "type": "module",
-  "version": "2.0.3",
+  "version": "2.0.4-beta.1",
   "description": "Integrate Umami Analytics into Nuxt",
   "author": "ML <me.mlaure@gmail.com>",
   "license": "MIT",

--- a/utils/umami.ts
+++ b/utils/umami.ts
@@ -1,4 +1,4 @@
-import { assert, collect, getConfig, getPayload, preflight } from '../internal/utils';
+import { collect, getPayload, preflight, umConfig } from '../internal/utils';
 import type { EventData, EventPayload, ViewPayload } from '../internal/types';
 import { helloDebugger } from '../internal/debug';
 
@@ -10,9 +10,7 @@ import { helloDebugger } from '../internal/debug';
  * @param referer page referrer, `document.referrer`
  */
 function trackView(url?: string, referrer?: string): void {
-  const { id, host, domains, ignoreDnt, ignoreLocal } = getConfig();
-
-  const check = preflight({ domains, ignoreDnt, id, host, ignoreLocal });
+  const check = preflight();
 
   if (check === 'ssr') {
     return;
@@ -23,8 +21,7 @@ function trackView(url?: string, referrer?: string): void {
     return;
   }
 
-  assert(typeof id === 'string');
-
+  const { id } = umConfig.value;
   const { pageReferrer, pageUrl, payload } = getPayload();
 
   void collect(
@@ -47,9 +44,7 @@ function trackView(url?: string, referrer?: string): void {
  * @param eventData additional data for the event, provide an object in the format `{key: value}`, `key` = string, `value` = string | number | or boolean.
  */
 function trackEvent(eventName: string, eventData?: EventData) {
-  const { id, host, domains, ignoreDnt, ignoreLocal } = getConfig();
-
-  const check = preflight({ domains, ignoreDnt, host, id, ignoreLocal });
+  const check = preflight();
 
   if (check === 'ssr') {
     return;
@@ -60,8 +55,7 @@ function trackEvent(eventName: string, eventData?: EventData) {
     return;
   }
 
-  assert(typeof id === 'string');
-
+  const { id } = umConfig.value;
   const { payload } = getPayload();
   const name = eventName || '#unknown-event';
 

--- a/utils/umami.ts
+++ b/utils/umami.ts
@@ -1,4 +1,4 @@
-import { assert, collect, getPayload, preflight } from '../internal/utils';
+import { assert, collect, getConfig, getPayload, preflight } from '../internal/utils';
 import type { EventData, EventPayload, ViewPayload } from '../internal/types';
 import { helloDebugger } from '../internal/debug';
 
@@ -10,13 +10,7 @@ import { helloDebugger } from '../internal/debug';
  * @param referer page referrer, `document.referrer`
  */
 function trackView(url?: string, referrer?: string): void {
-  const {
-    umami: {
-      id, host, domains,
-      ignoreDnt = false,
-      ignoreLocalhost: ignoreLocal = false,
-    } = {},
-  } = useAppConfig();
+  const { id, host, domains, ignoreDnt, ignoreLocal } = getConfig();
 
   const check = preflight({ domains, ignoreDnt, id, host, ignoreLocal });
 
@@ -53,13 +47,7 @@ function trackView(url?: string, referrer?: string): void {
  * @param eventData additional data for the event, provide an object in the format `{key: value}`, `key` = string, `value` = string | number | or boolean.
  */
 function trackEvent(eventName: string, eventData?: EventData) {
-  const {
-    umami: {
-      id, host, domains,
-      ignoreDnt = false,
-      ignoreLocalhost: ignoreLocal = false,
-    } = {},
-  } = useAppConfig();
+  const { id, host, domains, ignoreDnt, ignoreLocal } = getConfig();
 
   const check = preflight({ domains, ignoreDnt, host, id, ignoreLocal });
 


### PR DESCRIPTION
As requested by @tmlmt in #36