### PR TITLE
feat: add support for custom endpoints (COLLECT_API_ENDPOINT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ defineNuxtConfig({
 });
 ```
 
+#### Environment Variables
+
+> **Note**:
+> Available in `^2.1.0` and takes precedence over `appConfig`.
+
+You can provide the `host` and `id` config (only) as environment variables. Simply add `NUXT_PUBLIC_UMAMI_HOST` and `NUXT_PUBLIC_UMAMI_ID` to your `.env` file, and that's it.
+
+```sh
+NUXT_PUBLIC_UMAMI_HOST="https://domain.tld"
+NUXT_PUBLIC_UMAMI_ID="abc123-456def-ghi789"
+```
+
 ### Step 3:
 
 Use it.
@@ -101,19 +113,8 @@ Use it.
 | ignoreDnt | `boolean` | Option to ignore browsers' Do Not Track setting. | no | `true` |
 | autoTrack | `boolean` | Option to automatically track page views. | no | `true` |
 | ignoreLocalhost | `boolean` | Option to prevent tracking on localhost. | no | `false` |
-| version | `1 \| 2`  | Umami version (Cloud) | no | `1` |
-
-### Environment Variables
-
-> **Note**:
-> Available in `^2.1.0` and takes precedence over `appConfig`.
-
-You can provide the `host` and `id` config as environment variables. Simply add `NUXT_PUBLIC_UMAMI_HOST` and `NUXT_PUBLIC_UMAMI_ID` to your `.env` file, and that's it.
-
-```sh
-NUXT_PUBLIC_UMAMI_HOST="https://domain.tld"
-NUXT_PUBLIC_UMAMI_ID="abc123-456def-ghi789"
-```
+| customEndpoint | `string` | Set a custom `COLLECT_API_ENDPOINT`. See [Docs](https://umami.is/docs/environment-variables). | no | `undefined`
+| version | `1 \| 2` | Umami version (Cloud) | no | `1` |
 
 ## Usage
 

--- a/internal/utils.ts
+++ b/internal/utils.ts
@@ -33,10 +33,16 @@ const umConfig = computed(() => {
       ignoreDnt = true,
       ignoreLocalhost: ignoreLocal = false,
       autoTrack = true,
-      customEndpoint = undefined,
+      customEndpoint: customEP = undefined,
       version = 1,
     } = {},
   } = useAppConfig();
+
+  const customEndpoint = !isValidString(customEP)
+    ? undefined
+    : customEP.startsWith('/')
+      ? customEP
+      : `/${customEP}`;
 
   return {
     host: umamiHost || host,
@@ -124,10 +130,7 @@ function getPayload(): GetPayloadReturn {
 async function collect(load: ServerPayload) {
   const { host, customEndpoint, version } = umConfig.value;
   const root = new URL(host);
-  let branch = version === 2 ? '/api/send' : '/api/collect';
-  if (customEndpoint) {
-    branch = customEndpoint;
-  }
+  const branch = customEndpoint || (version === 2 ? '/api/send' : '/api/collect');
   const endpoint = `${root.protocol}//${root.host}${branch}`;
 
   fetch(endpoint, {

--- a/internal/utils.ts
+++ b/internal/utils.ts
@@ -33,6 +33,7 @@ const umConfig = computed(() => {
       ignoreDnt = true,
       ignoreLocalhost: ignoreLocal = false,
       autoTrack = true,
+      customEndpoint = undefined,
       version = 1,
     } = {},
   } = useAppConfig();
@@ -44,6 +45,7 @@ const umConfig = computed(() => {
     ignoreDnt,
     ignoreLocal,
     autoTrack,
+    customEndpoint,
     version,
   };
 });
@@ -120,10 +122,13 @@ function getPayload(): GetPayloadReturn {
 }
 
 async function collect(load: ServerPayload) {
-  const { host, version } = umConfig.value;
+  const { host, customEndpoint, version } = umConfig.value;
   const root = new URL(host);
-  const branch = version === 2 ? 'api/send' : 'api/collect';
-  const endpoint = `${root.protocol}//${root.host}/${branch}`;
+  let branch = version === 2 ? '/api/send' : '/api/collect';
+  if (customEndpoint) {
+    branch = customEndpoint;
+  }
+  const endpoint = `${root.protocol}//${root.host}${branch}`;
 
   fetch(endpoint, {
     method: 'POST',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -71,6 +71,10 @@ declare module '@nuxt/schema' {
        * @default 1
        */
       version?: 1 | 2
+      /**
+       * Self-hosted Umami lets you set a COLLECT_API_ENDPOINT, which is `/api/collect` by default. See Umami Docs: https://umami.is/docs/environment-variables
+       */
+      customEndpoint?: `/${string}`
     }
   }
 
@@ -83,6 +87,7 @@ declare module '@nuxt/schema' {
       ignoreDnt?: boolean
       ignoreLocalhost?: boolean
       version?: 1 | 2
+      customEndpoint?: `/${string}`
     }
   }
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -72,7 +72,7 @@ declare module '@nuxt/schema' {
        */
       version?: 1 | 2
       /**
-       * Self-hosted Umami lets you set a COLLECT_API_ENDPOINT, which is `/api/collect` by default. See Umami Docs: https://umami.is/docs/environment-variables
+       * Self-hosted Umami lets you set a COLLECT_API_ENDPOINT, which is `/api/collect` by default. See Umami [Docs](https://umami.is/docs/environment-variables).
        */
       customEndpoint?: `/${string}`
     }


### PR DESCRIPTION
Self hosted umami instances allow to change the collect endpoint: (env: COLLECT_API_ENDPOINT)