### PR TITLE
fix: `app.vue` conflict

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,0 @@
-<template>
-  <div>
-    Hello World!
-  </div>
-</template>


### PR DESCRIPTION
Umami's `app.vue` overrides if `app.vue` does not exist on "base" layer.