### PR TITLE
fix: Update types.ts to comply with TS isolatedModules

### DIFF
--- a/internal/types.ts
+++ b/internal/types.ts
@@ -8,7 +8,7 @@ interface BasicPayload {
   referrer: string
 }
 
-export interface EventData {
+interface EventData {
   [key: string]: string | number | boolean
 }
 
@@ -21,20 +21,31 @@ type EventPayloadPartial =
     event_data?: EventData
   };
 
-export type EventPayload = BasicPayload & EventPayloadPartial;
-export type ViewPayload = BasicPayload;
+  type EventPayload = BasicPayload & EventPayloadPartial;
+  type ViewPayload = BasicPayload;
 
-export type PartialPayload = Omit<BasicPayload, 'website'>;
-export type PayloadType = 'pageview' | 'event';
-export type PreflightResult = 'ssr' | 'id' | 'host' | 'domain' | 'dnt' | 'local' | true;
+type PartialPayload = Omit<BasicPayload, 'website'>;
+type PayloadType = 'pageview' | 'event';
+type PreflightResult = 'ssr' | 'id' | 'host' | 'domain' | 'dnt' | 'local' | true;
 
-export interface ServerPayload {
+interface ServerPayload {
   type: PayloadType
   payload: ViewPayload | EventPayload
 }
 
-export interface GetPayloadReturn {
+interface GetPayloadReturn {
   payload: PartialPayload
   pageUrl: string
   pageReferrer: string
 }
+
+export type {
+  EventData,
+  PartialPayload,
+  EventPayload,
+  ViewPayload,
+  PayloadType,
+  ServerPayload,
+  PreflightResult,
+  GetPayloadReturn,
+};

--- a/internal/types.ts
+++ b/internal/types.ts
@@ -8,7 +8,7 @@ interface BasicPayload {
   referrer: string
 }
 
-interface EventData {
+export interface EventData {
   [key: string]: string | number | boolean
 }
 
@@ -21,31 +21,20 @@ type EventPayloadPartial =
     event_data?: EventData
   };
 
-  type EventPayload = BasicPayload & EventPayloadPartial;
-  type ViewPayload = BasicPayload;
+export type EventPayload = BasicPayload & EventPayloadPartial;
+export type ViewPayload = BasicPayload;
 
-type PartialPayload = Omit<BasicPayload, 'website'>;
-type PayloadType = 'pageview' | 'event';
-type PreflightResult = 'ssr' | 'id' | 'host' | 'domain' | 'dnt' | 'local' | true;
+export type PartialPayload = Omit<BasicPayload, 'website'>;
+export type PayloadType = 'pageview' | 'event';
+export type PreflightResult = 'ssr' | 'id' | 'host' | 'domain' | 'dnt' | 'local' | true;
 
-interface ServerPayload {
+export interface ServerPayload {
   type: PayloadType
   payload: ViewPayload | EventPayload
 }
 
-interface GetPayloadReturn {
+export interface GetPayloadReturn {
   payload: PartialPayload
   pageUrl: string
   pageReferrer: string
 }
-
-export {
-  EventData,
-  PartialPayload,
-  EventPayload,
-  ViewPayload,
-  PayloadType,
-  ServerPayload,
-  PreflightResult,
-  GetPayloadReturn,
-};


### PR DESCRIPTION
With the current export the module can produce a runtime error as we're trying to export types as if they were actual runtime elements. For this reason Typescript warns about it if the isolatedModules property is set.

https://www.typescriptlang.org/tsconfig#isolatedModules

Here an example of the current error using latest version of Nuxt (3.7.0)
<img width="1161" alt="image" src="https://github.com/ijkml/nuxt-umami/assets/46224115/c9db3442-cdd7-4c69-a8da-5eaa09abda79">

