### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ Integrate [**Umami Analytics**](https://umami.is/) into your Nuxt websites / app
 Install using your favorite package manager...
 
 ```bash
-pnpm add nuxt-umami #pnpm
+npx nuxi@latest module add umami
 ```
 
 ```bash
-npm install nuxt-umami #npm
+npx nuxi@latest module add umami
 ```
 
 Then add `nuxt-umami` to your `extends` array in `nuxt.config`:

--- a/README.md
+++ b/README.md
@@ -30,11 +30,7 @@ Integrate [**Umami Analytics**](https://umami.is/) into your Nuxt websites / app
 
 ### Step 1: Install and add to Nuxt
 
-Install using your favorite package manager...
-
-```bash
-npx nuxi@latest module add umami
-```
+Install using nuxi...
 
 ```bash
 npx nuxi@latest module add umami


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
