### PR TITLE
feat: tracking functions return fetch promise with `ok` status

### DIFF
--- a/.playground/app.vue
+++ b/.playground/app.vue
@@ -2,7 +2,10 @@
 const shareUrl = 'https://savory.vercel.app/share/j2f1spIBFqHJKsXv/Nuxt%20Umami';
 
 function testView() {
-  umTrackView();
+  umTrackView().then(({ ok }) => {
+    // eslint-disable-next-line no-console
+    console.log(ok ? 'That went well ;)' : `Oops, that didn't go as planned`);
+  });
 }
 
 function testEvent() {

--- a/internal/types.ts
+++ b/internal/types.ts
@@ -33,6 +33,8 @@ interface ServerPayload {
   payload: ViewPayload | EventPayload;
 }
 
+type FetchResult = Promise<{ ok: boolean }>;
+
 export type {
   EventData,
   PartialPayload,
@@ -41,4 +43,5 @@ export type {
   PayloadType,
   ServerPayload,
   PreflightResult,
+  FetchResult,
 };


### PR DESCRIPTION
`umTrackView()` and `umTrackEvent()` now return a `then()`-able `Promise<{ok: boolean}>`.

Closes #98.