### PR TITLE
Simplify proxy check for SSR in module.ts

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -74,8 +74,8 @@ export default defineNuxtModule<ModuleOptions>({
 
     if (enabled && endpoint && id) {
       // ^ module is enabled && endpoint/id has no errors
-      if (proxyOpts.includes(proxy) && nuxt.options.ssr) {
-        // ^ ssr is enabled, requests can be proxied
+      if (proxyOpts.includes(proxy)) {
+        // ^ proxy is enabled, requests can be proxied
         if (proxy === 'cloak') {
           // ^ proxy mode: cloak; add API route
           mode = 'proxy';


### PR DESCRIPTION
Allows to use proxy without SSR,

I tested this locally and it works perfectly fine in a Nuxt 4 app with ssr: false.

Resolves issue: https://github.com/ijkml/nuxt-umami/issues/139

Thanks for your work on this module !