### PR TITLE
feat: add performance tracking option (Web Vitals)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,32 @@
 # Nuxt Umami
 
-[![npm](https://img.shields.io/npm/v/nuxt-umami?style=flat-square)](https://www.npmjs.com/package/nuxt-umami/)
-[![Downloads](https://img.shields.io/npm/dt/nuxt-umami.svg?style=flat-square)](https://www.npmjs.com/package/nuxt-umami)
 [![License](https://img.shields.io/npm/l/nuxt-umami?style=flat-square)](https://github.com/ijkml/nuxt-umami/blob/main/LICENSE)
-[![Sponsor](https://img.shields.io/badge/Sponsor-21262d?style=flat-square&logo=github&logoColor=db61a2)](https://github.com/sponsors/ijkml)
 
 Integrate [**Umami Analytics**](https://umami.is/) into your Nuxt websites/applications.
-
-## 🚀 Try it online
-
-<a href="https://stackblitz.com/edit/nuxt-umami"><img src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz"></a>
-
-## ✨ Get started
-
-Install and add to Nuxt with one command
-
-```sh
-npx nuxi module add nuxt-umami
-```
-
-## 📖 Config options, Usage, and FAQs
-
-[Read the full documentation.](https://umami.nuxt.dev/)
 
 ---
 
 ## Fork: colinmollenhour/nuxt-umami
 
 This fork adds several bug fixes and improvements on top of the upstream
-[ijkml/nuxt-umami](https://github.com/ijkml/nuxt-umami) v3.2.1. See
-[TODO.md](./TODO.md) for full details. Use this if you need:
+[ijkml/nuxt-umami](https://github.com/ijkml/nuxt-umami) v3.2.1.
+Use this if you need:
 
 - Distinct user ID support in `umIdentify` for authenticated SaaS users (Umami v2.18.0+)
 - Accurate geo-location when using `proxy: 'cloak'` on Netlify/Vercel
 - Fixed duplicate pageview tracking with nested `<NuxtPage>` layouts
-- Nuxt v4 compatibility
+- True runtime env var support — change Umami endpoint/ID at server start without rebuilding
 
 ### Install this fork
 
-**pnpm**
-```sh
-pnpm add github:colinmollenhour/nuxt-umami#v3.4.0
-```
+Install from the release tarball (the only supported method — `dist/` is not committed to git):
 
-**npm**
-```sh
-npm install github:colinmollenhour/nuxt-umami#v3.4.0
-```
-
-**yarn**
-```sh
-yarn add github:colinmollenhour/nuxt-umami#v3.4.0
-```
-
-Or pin to the release tarball for reproducible installs:
 ```sh
 pnpm add https://github.com/colinmollenhour/nuxt-umami/releases/download/v3.4.0/nuxt-umami-v3.4.0.tgz
+# or
+npm install https://github.com/colinmollenhour/nuxt-umami/releases/download/v3.4.0/nuxt-umami-v3.4.0.tgz
+# or
+yarn add https://github.com/colinmollenhour/nuxt-umami/releases/download/v3.4.0/nuxt-umami-v3.4.0.tgz
 ```
 
 > **Note:** Because this fork is not published to npm, `npx nuxi module add` will not
@@ -69,8 +40,8 @@ Add to `nuxt.config.ts`:
 export default defineNuxtConfig({
   modules: ['nuxt-umami'],
   umami: {
-    id: 'your-website-id',
     host: 'https://your-umami-instance.example.com',
+    id: 'your-website-id',
     autoTrack: true,
     // proxy: 'cloak',       // hide your Umami endpoint from the browser
     // useDirective: true,   // enable v-umami directive
@@ -80,7 +51,32 @@ export default defineNuxtConfig({
 });
 ```
 
+The `host` and `id` values above are build-time defaults. To override them at server start
+without rebuilding, use the environment variables described below.
+
 Full configuration reference: [umami.nuxt.dev/api/configuration](https://umami.nuxt.dev/api/configuration)
+
+### Environment variables
+
+Config values are stored in Nuxt `runtimeConfig` and can be overridden at **server start**
+(no rebuild required) using these env vars:
+
+```sh
+# proxy: false or proxy: 'direct'  (public — included in client bundle)
+NUXT_PUBLIC_UMAMI_WEBSITE=your-website-id
+NUXT_PUBLIC_UMAMI_ENDPOINT=https://your-umami-instance.example.com/api/send
+
+# proxy: 'cloak'  (server-only — never exposed to the client)
+NUXT_UMAMI_WEBSITE=your-website-id
+NUXT_UMAMI_ENDPOINT=https://your-umami-instance.example.com/api/send
+
+# Optional — overrides the tag at runtime (all proxy modes)
+NUXT_PUBLIC_UMAMI_TAG=my-tag
+```
+
+> Note: `NUXT_PUBLIC_UMAMI_ENDPOINT` is the fully-resolved endpoint URL including the
+> path (e.g. `/api/send`). It corresponds to `host` + `customEndpoint` from the module
+> options, not `host` alone.
 
 ### Usage
 
@@ -103,8 +99,8 @@ umTrackRevenue('subscription', 49, 'USD');
 
 ### Fork changes vs upstream v3.2.1
 
-| Fix | Description |
-|-----|-------------|
+| Change | Description |
+|--------|-------------|
 | SPA referral attribution | `?ref=` param was sent on every page, not just the landing page |
 | Duplicate pageview | Nested `<NuxtPage>` caused double-tracking per navigation |
 | `umIdentify` distinct ID | Added `(id)` and `(id, data)` signatures; ID auto-included in all subsequent events |
@@ -112,10 +108,10 @@ umTrackRevenue('subscription', 49, 'USD');
 | Event name length | Names over 50 chars are warned and pre-truncated to match Umami's server limit |
 | Currency normalization | `umTrackRevenue` now always emits uppercase currency codes |
 | Nuxt v4 peer deps | `@nuxt/kit`/`@nuxt/schema` ranges broadened to `>=3.15.4` |
-| Runtime config typing | `runtimeConfig.umami` is now properly typed (was untyped `_proxyUmConfig`) |
+| Runtime config typing | `runtimeConfig.umami` is now properly typed via module augmentation |
 | Structured logging | Module setup uses `useLogger` from `@nuxt/kit` instead of `console.warn` |
 | Proxy validator | Body key-count check removed; forward-compatible with Umami API additions |
-| Runtime env vars | Config moved to Nuxt `runtimeConfig`; `NUXT_PUBLIC_UMAMI_*` / `NUXT_UMAMI_*` now override at server start (not build time) |
+| Runtime env vars | Config moved to Nuxt `runtimeConfig`; `NUXT_PUBLIC_UMAMI_*` / `NUXT_UMAMI_*` override at server start, not build time |
 
 ---
 
@@ -130,35 +126,35 @@ Use this prompt when setting up this module in a new project:
 > fixes; the full API and configuration docs are at https://umami.nuxt.dev/ but
 > installation differs from the official docs.
 >
-> **Install:**
- > ```sh
+> **Install from the release tarball** (the only supported method — `npx nuxi module add`
+> and `github:` installs do not work for this fork):
+> ```sh
 > pnpm add https://github.com/colinmollenhour/nuxt-umami/releases/download/v3.4.0/nuxt-umami-v3.4.0.tgz
 > ```
 >
-> **Register in `nuxt.config.ts`** (do NOT use `npx nuxi module add` — it only works for
-> npm-published packages):
+> **Register in `nuxt.config.ts`:**
 > ```ts
 > export default defineNuxtConfig({
 >   modules: ['nuxt-umami'],
 >   umami: {
->     id: process.env.NUXT_UMAMI_ID,
->     host: process.env.NUXT_UMAMI_HOST,
+>     host: 'https://your-umami-instance.example.com',
+>     id: 'your-website-id',
 >     autoTrack: true,
 >     proxy: 'cloak',
 >   },
 > });
 > ```
 >
-> **Environment variables** — set at build time in `nuxt.config.ts` (`host`/`id`) or override
-> at server start with these env vars (no rebuild needed):
-> ```
-> # proxy: false or proxy: 'direct' (public — visible in client bundle)
-> NUXT_PUBLIC_UMAMI_WEBSITE=your-website-id
-> NUXT_PUBLIC_UMAMI_ENDPOINT=https://your-umami-instance.example.com/api/send
->
-> # proxy: 'cloak' (server-only — never exposed to the client)
+> **Environment variables** — these override the `host`/`id` values above at server start
+> (no rebuild needed). Use the set that matches your `proxy` setting:
+> ```sh
+> # proxy: 'cloak'  (server-only — never exposed to the client)
 > NUXT_UMAMI_WEBSITE=your-website-id
 > NUXT_UMAMI_ENDPOINT=https://your-umami-instance.example.com/api/send
+>
+> # proxy: false (default) or proxy: 'direct'  (public — in client bundle)
+> NUXT_PUBLIC_UMAMI_WEBSITE=your-website-id
+> NUXT_PUBLIC_UMAMI_ENDPOINT=https://your-umami-instance.example.com/api/send
 > ```
 >
 > **Auto-imported composables** (no imports needed in `<script setup>`):

--- a/README.md
+++ b/README.md
@@ -40,22 +40,22 @@ This fork adds several bug fixes and improvements on top of the upstream
 
 **pnpm**
 ```sh
-pnpm add github:colinmollenhour/nuxt-umami#v3.3.0
+pnpm add github:colinmollenhour/nuxt-umami#v3.4.0
 ```
 
 **npm**
 ```sh
-npm install github:colinmollenhour/nuxt-umami#v3.3.0
+npm install github:colinmollenhour/nuxt-umami#v3.4.0
 ```
 
 **yarn**
 ```sh
-yarn add github:colinmollenhour/nuxt-umami#v3.3.0
+yarn add github:colinmollenhour/nuxt-umami#v3.4.0
 ```
 
 Or pin to the release tarball for reproducible installs:
 ```sh
-pnpm add https://github.com/colinmollenhour/nuxt-umami/releases/download/v3.3.0/nuxt-umami-v3.3.0.tgz
+pnpm add https://github.com/colinmollenhour/nuxt-umami/releases/download/v3.4.0/nuxt-umami-v3.4.0.tgz
 ```
 
 > **Note:** Because this fork is not published to npm, `npx nuxi module add` will not
@@ -88,17 +88,17 @@ All composables are auto-imported. See [umami.nuxt.dev/api/usage](https://umami.
 
 ```ts
 // Track a page view (called automatically if autoTrack: true)
-umTrackView()
+umTrackView();
 
 // Track a named event with optional data
-umTrackEvent('signup-click', { plan: 'pro' })
+umTrackEvent('signup-click', { plan: 'pro' });
 
 // Identify an authenticated user (SaaS portal use case)
-umIdentify('[email protected]')
-umIdentify('[email protected]', { plan: 'pro', company: 'Acme' })
+umIdentify('[email protected]');
+umIdentify('[email protected]', { plan: 'pro', company: 'Acme' });
 
 // Track revenue
-umTrackRevenue('subscription', 49, 'USD')
+umTrackRevenue('subscription', 49, 'USD');
 ```
 
 ### Fork changes vs upstream v3.2.1
@@ -115,6 +115,7 @@ umTrackRevenue('subscription', 49, 'USD')
 | Runtime config typing | `runtimeConfig.umami` is now properly typed (was untyped `_proxyUmConfig`) |
 | Structured logging | Module setup uses `useLogger` from `@nuxt/kit` instead of `console.warn` |
 | Proxy validator | Body key-count check removed; forward-compatible with Umami API additions |
+| Runtime env vars | Config moved to Nuxt `runtimeConfig`; `NUXT_PUBLIC_UMAMI_*` / `NUXT_UMAMI_*` now override at server start (not build time) |
 
 ---
 
@@ -131,7 +132,7 @@ Use this prompt when setting up this module in a new project:
 >
 > **Install:**
  > ```sh
-> pnpm add https://github.com/colinmollenhour/nuxt-umami/releases/download/v3.3.0/nuxt-umami-v3.3.0.tgz
+> pnpm add https://github.com/colinmollenhour/nuxt-umami/releases/download/v3.4.0/nuxt-umami-v3.4.0.tgz
 > ```
 >
 > **Register in `nuxt.config.ts`** (do NOT use `npx nuxi module add` — it only works for
@@ -145,13 +146,19 @@ Use this prompt when setting up this module in a new project:
 >     autoTrack: true,
 >     proxy: 'cloak',
 >   },
-> })
+> });
 > ```
 >
-> **Environment variables** (add to `.env` and your deployment secrets):
+> **Environment variables** — set at build time in `nuxt.config.ts` (`host`/`id`) or override
+> at server start with these env vars (no rebuild needed):
 > ```
-> NUXT_UMAMI_ID=your-website-id
-> NUXT_UMAMI_HOST=https://your-umami-instance.example.com
+> # proxy: false or proxy: 'direct' (public — visible in client bundle)
+> NUXT_PUBLIC_UMAMI_WEBSITE=your-website-id
+> NUXT_PUBLIC_UMAMI_ENDPOINT=https://your-umami-instance.example.com/api/send
+>
+> # proxy: 'cloak' (server-only — never exposed to the client)
+> NUXT_UMAMI_WEBSITE=your-website-id
+> NUXT_UMAMI_ENDPOINT=https://your-umami-instance.example.com/api/send
 > ```
 >
 > **Auto-imported composables** (no imports needed in `<script setup>`):

--- a/README.md
+++ b/README.md
@@ -23,6 +23,154 @@ npx nuxi module add nuxt-umami
 
 [Read the full documentation.](https://umami.nuxt.dev/)
 
+---
+
+## Fork: colinmollenhour/nuxt-umami
+
+This fork adds several bug fixes and improvements on top of the upstream
+[ijkml/nuxt-umami](https://github.com/ijkml/nuxt-umami) v3.2.1. See
+[TODO.md](./TODO.md) for full details. Use this if you need:
+
+- Distinct user ID support in `umIdentify` for authenticated SaaS users (Umami v2.18.0+)
+- Accurate geo-location when using `proxy: 'cloak'` on Netlify/Vercel
+- Fixed duplicate pageview tracking with nested `<NuxtPage>` layouts
+- Nuxt v4 compatibility
+
+### Install this fork
+
+**pnpm**
+```sh
+pnpm add github:colinmollenhour/nuxt-umami#v3.3.0
+```
+
+**npm**
+```sh
+npm install github:colinmollenhour/nuxt-umami#v3.3.0
+```
+
+**yarn**
+```sh
+yarn add github:colinmollenhour/nuxt-umami#v3.3.0
+```
+
+Or pin to the release zip for reproducible installs:
+```sh
+pnpm add https://github.com/colinmollenhour/nuxt-umami/releases/download/v3.3.0/nuxt-umami-v3.3.0.zip
+```
+
+> **Note:** Because this fork is not published to npm, `npx nuxi module add` will not
+> work. Register the module manually as shown below.
+
+### Configure
+
+Add to `nuxt.config.ts`:
+
+```ts
+export default defineNuxtConfig({
+  modules: ['nuxt-umami'],
+  umami: {
+    id: 'your-website-id',
+    host: 'https://your-umami-instance.example.com',
+    autoTrack: true,
+    // proxy: 'cloak',       // hide your Umami endpoint from the browser
+    // useDirective: true,   // enable v-umami directive
+    // ignoreLocalhost: true,
+    // domains: ['mysite.com'],
+  },
+});
+```
+
+Full configuration reference: [umami.nuxt.dev/api/configuration](https://umami.nuxt.dev/api/configuration)
+
+### Usage
+
+All composables are auto-imported. See [umami.nuxt.dev/api/usage](https://umami.nuxt.dev/api/usage) for the full API.
+
+```ts
+// Track a page view (called automatically if autoTrack: true)
+umTrackView()
+
+// Track a named event with optional data
+umTrackEvent('signup-click', { plan: 'pro' })
+
+// Identify an authenticated user (SaaS portal use case)
+umIdentify('[email protected]')
+umIdentify('[email protected]', { plan: 'pro', company: 'Acme' })
+
+// Track revenue
+umTrackRevenue('subscription', 49, 'USD')
+```
+
+### Fork changes vs upstream v3.2.1
+
+| Fix | Description |
+|-----|-------------|
+| SPA referral attribution | `?ref=` param was sent on every page, not just the landing page |
+| Duplicate pageview | Nested `<NuxtPage>` caused double-tracking per navigation |
+| `umIdentify` distinct ID | Added `(id)` and `(id, data)` signatures; ID auto-included in all subsequent events |
+| Cloak proxy geo-location | `X-Forwarded-For` now forwarded so Umami sees the real client IP |
+| Event name length | Names over 50 chars are warned and pre-truncated to match Umami's server limit |
+| Currency normalization | `umTrackRevenue` now always emits uppercase currency codes |
+| Nuxt v4 peer deps | `@nuxt/kit`/`@nuxt/schema` ranges broadened to `>=3.15.4` |
+| Runtime config typing | `runtimeConfig.umami` is now properly typed (was untyped `_proxyUmConfig`) |
+| Structured logging | Module setup uses `useLogger` from `@nuxt/kit` instead of `console.warn` |
+| Proxy validator | Body key-count check removed; forward-compatible with Umami API additions |
+
+---
+
+## Prompt for AI assistants
+
+Use this prompt when setting up this module in a new project:
+
+---
+
+> Install the `colinmollenhour/nuxt-umami` fork of the nuxt-umami module. This is a
+> fork of [ijkml/nuxt-umami](https://github.com/ijkml/nuxt-umami) with additional bug
+> fixes; the full API and configuration docs are at https://umami.nuxt.dev/ but
+> installation differs from the official docs.
+>
+> **Install:**
+> ```sh
+> pnpm add https://github.com/colinmollenhour/nuxt-umami/releases/download/v3.3.0/nuxt-umami-v3.3.0.zip
+> ```
+>
+> **Register in `nuxt.config.ts`** (do NOT use `npx nuxi module add` — it only works for
+> npm-published packages):
+> ```ts
+> export default defineNuxtConfig({
+>   modules: ['nuxt-umami'],
+>   umami: {
+>     id: process.env.NUXT_UMAMI_ID,
+>     host: process.env.NUXT_UMAMI_HOST,
+>     autoTrack: true,
+>     proxy: 'cloak',
+>   },
+> })
+> ```
+>
+> **Environment variables** (add to `.env` and your deployment secrets):
+> ```
+> NUXT_UMAMI_ID=your-website-id
+> NUXT_UMAMI_HOST=https://your-umami-instance.example.com
+> ```
+>
+> **Auto-imported composables** (no imports needed in `<script setup>`):
+> - `umTrackView(path?, referrer?)` — track a page view
+> - `umTrackEvent(name, data?)` — track a named event; `name` max 50 chars
+> - `umIdentify(userId)` / `umIdentify(userId, data)` / `umIdentify(data)` — identify
+>   the current user; the ID persists across all subsequent events in the session
+> - `umTrackRevenue(name, amount, currency?)` — track a revenue event
+>
+> **Directive** (enable with `useDirective: true` in config):
+> ```html
+> <button v-umami="'cta-click'">Get started</button>
+> ```
+>
+> Full config and usage docs: https://umami.nuxt.dev/api/configuration and
+> https://umami.nuxt.dev/api/usage
+
+---
+
 <hr />
 
 MIT License ©2022-PRESENT [ML](https://github.com/ijkml/)

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ npm install github:colinmollenhour/nuxt-umami#v3.3.0
 yarn add github:colinmollenhour/nuxt-umami#v3.3.0
 ```
 
-Or pin to the release zip for reproducible installs:
+Or pin to the release tarball for reproducible installs:
 ```sh
-pnpm add https://github.com/colinmollenhour/nuxt-umami/releases/download/v3.3.0/nuxt-umami-v3.3.0.zip
+pnpm add https://github.com/colinmollenhour/nuxt-umami/releases/download/v3.3.0/nuxt-umami-v3.3.0.tgz
 ```
 
 > **Note:** Because this fork is not published to npm, `npx nuxi module add` will not
@@ -130,8 +130,8 @@ Use this prompt when setting up this module in a new project:
 > installation differs from the official docs.
 >
 > **Install:**
-> ```sh
-> pnpm add https://github.com/colinmollenhour/nuxt-umami/releases/download/v3.3.0/nuxt-umami-v3.3.0.zip
+ > ```sh
+> pnpm add https://github.com/colinmollenhour/nuxt-umami/releases/download/v3.3.0/nuxt-umami-v3.3.0.tgz
 > ```
 >
 > **Register in `nuxt.config.ts`** (do NOT use `npx nuxi module add` — it only works for

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,354 @@
+# nuxt-umami TODO
+
+> Research date: March 2026  
+> Sources: GitHub PRs/issues, upstream forks, Umami tracker docs, Nuxt v4 upgrade guide  
+> Use case focus: SaaS homepage, portal, and docs site
+
+---
+
+## Priority 1 — Critical Bug Fixes
+
+### 1.1 Merge PR #143: `umIdentify` distinct user ID support
+
+**Status:** Open PR from `garretto`, closes issues #145 and #138  
+**Files:** `src/types.ts:58`, `src/runtime/composables.ts:170`
+
+This is the most important missing feature for a SaaS portal. Umami v2.18.0+ supports
+associating events with a specific user ID, but `umIdentify` currently only accepts
+session data — there is no way to pass a distinct ID string.
+
+**Changes needed:**
+- Add `id?: string` to `IdentifyPayload` in `src/types.ts:58`
+- Add `parseEventBody` validator support for `id` field in `src/runtime/utils.ts:124`
+- Update `umIdentify` to accept overloads:
+  ```ts
+  function umIdentify(uniqueId: string, sessionData?: EventData): FetchResult
+  function umIdentify(sessionData?: EventData): FetchResult
+  ```
+- Store the ID in a module-level closure variable so it auto-includes in subsequent
+  event payloads (matching official Umami tracker behavior)
+
+**Why it matters for SaaS:** When a user logs into a portal, you want `umIdentify('[email protected]')` 
+to associate all subsequent page views and events with that user for cohort analysis.
+
+---
+
+### 1.2 Fix double `umTrackView` with nested `<NuxtPage>` (Issue #141)
+
+**Status:** Open issue, no PR yet  
+**File:** `src/runtime/plugin.ts:15-18`
+
+The `page:finish` hook fires once per `<NuxtPage>` component in nested routes, causing
+duplicate pageview events that skew analytics data.
+
+**Fix:** Track the last sent `route.fullPath` and deduplicate:
+```ts
+let lastTrackedPath: string | undefined;
+
+nuxtApp.hook('page:finish', () => {
+  const currentPath = nuxtApp.$router.currentRoute.value.fullPath;
+  if (currentPath === lastTrackedPath) return;
+  lastTrackedPath = currentPath;
+  setTimeout(umTrackView, 250);
+});
+```
+
+---
+
+### 1.3 Fix `queryRef` not resetting on SPA navigation
+
+**Status:** Bug (not yet reported as issue)  
+**File:** `src/runtime/composables.ts:16-17`, `composables.ts:67-75`
+
+`queryRef` is a module-level variable initialized once from the URL's `?ref=` or
+`?referrer=` param. In a SPA, navigating away from the landing page still sends the
+original referral source with every subsequent pageview, inflating referral attribution.
+
+**Fix:** Reset `queryRef` after the first pageview send, or re-derive it on each
+`umTrackView` call from the current route rather than memoizing it.
+
+---
+
+## Priority 2 — Nuxt v4 Compatibility
+
+### 2.1 Update peer dependency versions
+
+**File:** `package.json`
+
+```json
+// Current
+"@nuxt/kit": "^3.15.4"  // devDep
+"@nuxt/schema": "^3.15.4"  // devDep
+"nuxt": "^3.15.4"  // devDep
+
+// Required for v4
+"@nuxt/kit": ">=3.15.4"
+"@nuxt/schema": "^4.0.0"
+"nuxt": "^4.0.0"
+```
+
+Also update `@nuxt/module-builder` to the latest version that supports v4.
+
+---
+
+### 2.2 Investigate `page:loading:end` hook as replacement for setTimeout hack
+
+**File:** `src/runtime/plugin.ts:15-18`
+
+There are multiple `// TODO` comments acknowledging the `setTimeout(umTrackView, 250)` 
+hack used to wait for `useHead()` to update the page title after navigation. This was
+a workaround for Nuxt bug #26535.
+
+In Nuxt v4, `page:loading:end` is reported as fixed. If confirmed, replace:
+```ts
+// Current workaround
+nuxtApp.hook('page:finish', () => {
+  setTimeout(umTrackView, 250);
+});
+
+// Cleaner v4 approach (validate #26535 is fixed first)
+nuxtApp.hook('page:loading:end', () => {
+  umTrackView();
+});
+```
+
+---
+
+### 2.3 Type the `_proxyUmConfig` runtime config key properly
+
+**Files:** `src/module.ts:123`, `src/runtime/server/endpoint.ts:24`
+
+The `_proxyUmConfig` key is set on `runtimeConfig` without a declared type. In Nuxt v4
+this generates TypeScript errors in strict mode. Declare it in the module options schema:
+
+```ts
+// In module.ts defineNuxtModule options
+runtimeConfig: {
+  umami: {
+    endpoint: '',
+    website: '',
+    domains: '',
+  }
+}
+```
+
+Update `endpoint.ts:24` accordingly: `useRuntimeConfig().umami` instead of
+`useRuntimeConfig()._proxyUmConfig`.
+
+---
+
+### 2.4 Replace `console.warn`/`console.info` with `useLogger`
+
+**File:** `src/module.ts:108-119`
+
+Nuxt v4 convention uses consola-based logging via `useLogger` from `@nuxt/kit`:
+```ts
+import { useLogger } from '@nuxt/kit'
+const logger = useLogger('nuxt-umami')
+logger.warn('id is missing...')
+```
+
+---
+
+### 2.5 Update `meta.compatibility` declaration
+
+**File:** `src/module.ts:21`
+
+```ts
+// Current
+compatibility: { nuxt: '>=3' }
+
+// Updated
+compatibility: { nuxt: '>=3.0.0' }
+```
+
+---
+
+### 2.6 Migrate playground to Nuxt v4 `app/` directory structure
+
+**Files:** `playground/` directory, `playground/nuxt.config.ts`
+
+Nuxt v4 defaults to `srcDir: 'app/'`. Either:
+- Add `srcDir: '.'` to `playground/nuxt.config.ts` to opt out explicitly, OR
+- Move `app.vue`, `pages/`, `assets/` into `playground/app/`
+
+Also update the `compatibilityDate` in `playground/nuxt.config.ts` from `'2024-08-08'`
+to a current date.
+
+---
+
+## Priority 3 — Runtime Config for Multi-Tenant SaaS (Issue #132)
+
+**Status:** Open issue labeled `enhancement, help wanted`; PR #134 was closed without merge
+
+The current architecture bakes `host` and `id` at **build time** via `addTemplate` 
+generating `#build/umami.config.mjs`. This means a single Docker image cannot serve
+multiple tenants with different Umami website IDs.
+
+**Goal:** Allow `NUXT_PUBLIC_UMAMI_HOST` and `NUXT_PUBLIC_UMAMI_ID` environment variables
+to work as true runtime overrides (read at server start, not build time).
+
+**Approach:**
+1. Move `id` and `host` into `runtimeConfig.public` instead of a build-time template
+2. Access them via `useRuntimeConfig().public.umami` in the client runtime
+3. Keep the current template approach as fallback for build-time config
+
+This is non-trivial because the current `#build/umami.config.mjs` template is used in
+client-side composables where `useRuntimeConfig()` is not always available (e.g., 
+non-Nuxt contexts). A careful implementation is needed.
+
+---
+
+## Priority 4 — Feature Improvements
+
+### 4.1 Support relative `host` path for same-origin proxy (Issue #144)
+
+**Status:** Open issue, no PR
+
+Users running Umami behind a reverse proxy at e.g. `/_umami` on the same domain as their
+Nuxt app cannot currently configure `host: '/_umami'` — the module calls `new URL(host).origin`
+which fails on relative paths.
+
+**Use case:** A SaaS company that proxies Umami at `/_umami` on their app domain to avoid
+ad-blocker detection without exposing the Umami cloud URL.
+
+**Fix in:** `src/module.ts` — check if `host` starts with `/` and handle as relative path,
+using `window.location.origin + host` at runtime.
+
+---
+
+### 4.2 Forward client IP in `cloak` proxy (Issue #137)
+
+**Status:** Open issue
+
+When using `proxy: 'cloak'` on Netlify/Vercel edge functions, all users appear to be
+located at the server's IP (US datacenter) because Umami sees the proxy's IP, not the
+end user's IP.
+
+**Fix in:** `src/runtime/server/endpoint.ts` — forward `X-Forwarded-For` and `X-Real-IP`
+headers from the incoming request to the Umami endpoint:
+
+```ts
+const clientIp = event.node.req.headers['x-forwarded-for'] 
+  || event.node.req.headers['x-real-ip'];
+
+if (clientIp) {
+  headers['X-Forwarded-For'] = clientIp as string;
+}
+```
+
+---
+
+### 4.3 Add event name length validation (50-char limit)
+
+**Status:** Not reported; identified from Umami docs  
+**File:** `src/runtime/composables.ts:144`
+
+Umami silently truncates event names longer than 50 characters. The current validation
+only checks that the name is non-empty:
+
+```ts
+// Add length check
+if (!isValidString(eventName) || eventName.length > 50) {
+  logger('event-name');
+  name = '#unknown-event';
+}
+```
+
+---
+
+### 4.4 Fix `currency` regex case-insensitive flag
+
+**Status:** Minor bug  
+**File:** `src/runtime/composables.ts:217`
+
+The `i` flag makes the regex accept `usd`, `Usd`, etc., but the value is stored as-is:
+```ts
+// Current (buggy — stores mixed-case value)
+if (/^[A-Z]{3}$/i.test(currency.trim())) {
+  $cur = currency.trim();
+}
+
+// Fixed
+if (/^[A-Z]{3}$/.test(currency.trim().toUpperCase())) {
+  $cur = currency.trim().toUpperCase();
+}
+```
+
+---
+
+### 4.5 Fix `CurrencyCode` type — missing letter `I`
+
+**Status:** Minor type bug  
+**File:** `src/types.ts:72-76`
+
+The `_Letter` union type that builds valid 3-letter currency codes is missing `I` 
+(which is a valid ISO 4217 prefix — e.g., `INR`, `IDR`, `ILS`, `IQD`, `IRR`).
+
+---
+
+### 4.6 Make proxy body validator forward-compatible
+
+**Status:** Low priority future-proofing  
+**File:** `src/runtime/utils.ts:204`
+
+The strict `Object.keys(body).length !== _bodyProps.length` check will silently reject
+requests if the Umami API ever adds a new top-level field. Change to check for required
+properties being present, not that no extra properties exist.
+
+---
+
+### 4.7 Add `doNotTrack` browser setting support
+
+**Status:** Feature gap vs. Umami official tracker  
+**Files:** `src/options.ts`, `src/runtime/composables.ts:29-43` (`runPreflight`)
+
+The official Umami tracker supports `data-do-not-track="true"` which respects the
+browser's `navigator.doNotTrack` header. The module has `ignoreLocalhost` but no DNT
+support.
+
+Add a `doNotTrack: boolean` option (default `false`) that, when `true`, checks
+`navigator.doNotTrack === '1'` in `runPreflight()` and suppresses tracking.
+
+---
+
+## Informational / Won't Fix
+
+### Forks analysis
+
+Both `garretto/nuxt-umami` and `XStarlink/nuxt-umami` forks contain only **one change**
+each — the same `src/module.ts` proxy SSR guard removal that was already merged into
+`v3.2.1`. There is nothing to cherry-pick from these forks; the current codebase is
+ahead of both.
+
+### Batch event processing (Issue #136)
+
+Umami v2 added batch API support. Closed without action upstream. Not relevant for a
+standard SaaS analytics use case — only matters at very high event volumes.
+
+### REST API for reading stats (Issue #109)
+
+Out of scope — a separate package/module concern. Use Umami's REST API directly if you
+need to display analytics data in your app.
+
+### Stale dev branches
+
+`feb-update` and `new-features` branches are stale — their content was already merged
+into `main`. Safe to delete.
+
+---
+
+## Implementation Order (Recommended)
+
+1. **Fix `queryRef` SPA referrer bug** (10 min, 1 file) — silent data corruption
+2. **Fix nested `<NuxtPage>` double tracking** (15 min, 1 file) — visible skew in data
+3. **Merge PR #143 source changes** (umIdentify distinct ID) — critical for portal
+4. **Nuxt v4 peer deps + compatibility meta** (30 min) — unblocks v4 users
+5. **Type `_proxyUmConfig` properly** (30 min, 2 files) — TypeScript correctness
+6. **Forward client IP in cloak proxy** (20 min, 1 file) — geo-location accuracy
+7. **Replace `console.warn` with `useLogger`** (15 min, 1 file) — convention
+8. **Event name 50-char validation** (5 min, 1 file) — developer experience
+9. **Currency regex fix** (5 min, 1 file) — silent bug
+10. **`page:loading:end` hook investigation** (research first, then implement)
+11. **Relative host path support** (Issue #144) — proxy ergonomics
+12. **Runtime config for multi-tenant** (Issue #132) — architecture change, plan carefully

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-umami",
   "type": "module",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "packageManager": "pnpm@10.4.1",
   "description": "Integrate Umami Analytics into Nuxt",
   "author": "Moses Laurence <me@ijkml.dev>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-umami",
   "type": "module",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "packageManager": "pnpm@10.4.1",
   "description": "Integrate Umami Analytics into Nuxt",
   "author": "Moses Laurence <me@ijkml.dev>",

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
     "test": "vue-tsc --noEmit && npm run lint && cd playground && vue-tsc --noEmit"
   },
   "dependencies": {
-    "@nuxt/kit": "^3.15.4",
+    "@nuxt/kit": ">=3.15.4",
     "request-ip": "^3.3.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^4.3.0",
     "@nuxt/module-builder": "^0.8.4",
-    "@nuxt/schema": "^3.15.4",
+    "@nuxt/schema": ">=3.15.4",
     "@types/node": "^22.13.4",
     "@types/request-ip": "^0.0.41",
     "bumpp": "^10.0.3",

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -21,6 +21,7 @@ export default defineNuxtConfig({
       excludeSearch: false,
       trailingSlash: 'always',
     },
+    performance: true,
   },
 
   appConfig: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@nuxt/kit':
-        specifier: ^3.15.4
+        specifier: '>=3.15.4'
         version: 3.15.4(magicast@0.3.5)
       request-ip:
         specifier: ^3.3.0
@@ -22,7 +22,7 @@ importers:
         specifier: ^0.8.4
         version: 0.8.4(@nuxt/kit@3.15.4(magicast@0.3.5))(nuxi@3.22.2)(typescript@5.6.3)(vue-tsc@2.2.2(typescript@5.6.3))
       '@nuxt/schema':
-        specifier: ^3.15.4
+        specifier: '>=3.15.4'
         version: 3.15.4
       '@types/node':
         specifier: ^22.13.4

--- a/src/module.ts
+++ b/src/module.ts
@@ -7,6 +7,7 @@ import {
   addTemplate,
   createResolver,
   defineNuxtModule,
+  useLogger,
 } from '@nuxt/kit';
 import { name, version } from '../package.json';
 import { isValidString, normalizeConfig } from './runtime/utils';
@@ -22,6 +23,7 @@ export default defineNuxtModule<ModuleOptions>({
     },
   },
   setup(options, nuxt) {
+    const logger = useLogger('nuxt-umami');
     const { resolve } = createResolver(import.meta.url);
 
     const pathTo = {
@@ -105,18 +107,18 @@ export default defineNuxtModule<ModuleOptions>({
     else {
       // ^ module is disabled || host/id has errors
       if (!id)
-        console.warn('[umami] id is missing or incorrectly configured. Check module config.');
+        logger.warn('id is missing or incorrectly configured. Check module config.');
       if (!endpoint) {
-        console.warn(
-          '[umami] Your API endpoint is missing or incorrectly configured. Check `host` and/or `customEndpoint` in module config.',
+        logger.warn(
+          'Your API endpoint is missing or incorrectly configured. Check `host` and/or `customEndpoint` in module config.',
         );
       }
 
-      console.info(`[umami] ${
+      logger.info(
         enabled
           ? 'Currently running in test mode due to incorrect/missing options.'
-          : 'Umami is disabled.'
-      }`);
+          : 'Umami is disabled.',
+      );
     }
 
     // add private config to runtime, only usable in server

--- a/src/module.ts
+++ b/src/module.ts
@@ -39,6 +39,9 @@ export default defineNuxtModule<ModuleOptions>({
     const runtimeConfig = nuxt.options.runtimeConfig;
     const ENV = process.env;
 
+    // Build-time env var defaults — these set the initial values baked into the
+    // runtimeConfig defaults. At server start, Nuxt will override them with the
+    // NUXT_PUBLIC_UMAMI_* / NUXT_UMAMI_* environment variables automatically.
     const envHost = ENV.NUXT_UMAMI_HOST || ENV.NUXT_PUBLIC_UMAMI_HOST;
     const envId = ENV.NUXT_UMAMI_ID || ENV.NUXT_PUBLIC_UMAMI_ID;
     const envTag = ENV.NUXT_UMAMI_TAG || ENV.NUXT_PUBLIC_UMAMI_TAG;
@@ -67,6 +70,8 @@ export default defineNuxtModule<ModuleOptions>({
       domains,
       website: '',
       endpoint: '',
+      mode: 'faux' as ModuleMode,
+      logErrors: process.env.NODE_ENV === 'development' || logErrors,
     } satisfies UmPublicConfig;
 
     const privateConfig: UmPrivateConfig = { endpoint: '', website: '', domains };
@@ -85,12 +90,17 @@ export default defineNuxtModule<ModuleOptions>({
             route: '/api/savory',
             handler: resolve('./runtime/server/endpoint'),
           });
+          // In cloak mode, endpoint/website are server-only — never put in public config.
+          // They are overridable at runtime via NUXT_UMAMI_ENDPOINT / NUXT_UMAMI_WEBSITE.
           privateConfig.endpoint = endpoint;
           privateConfig.website = id;
         }
         else if (proxy === 'direct') {
           // ^ proxy mode: direct; add proxy rule
           mode = 'direct';
+          // The client hits /api/savory, Nuxt proxies it to the real endpoint.
+          // routeRules is a build-time artifact — runtime override of the target
+          // URL is not possible in this mode without a rebuild.
           publicConfig.endpoint = '/api/savory';
           publicConfig.website = id;
           nuxt.options.routeRules ||= {};
@@ -98,7 +108,9 @@ export default defineNuxtModule<ModuleOptions>({
         }
       }
       else {
-        // ^ proxy mode: none; or ssr is disabled
+        // ^ proxy mode: none; direct to Umami
+        // endpoint/website go into public runtimeConfig and are overridable at
+        // runtime via NUXT_PUBLIC_UMAMI_ENDPOINT / NUXT_PUBLIC_UMAMI_WEBSITE.
         mode = 'direct';
         publicConfig.endpoint = endpoint;
         publicConfig.website = id;
@@ -121,22 +133,29 @@ export default defineNuxtModule<ModuleOptions>({
       );
     }
 
-    // add private config to runtime, only usable in server
-    // typed via UmPrivateConfig; accessed in server handler as useRuntimeConfig().umami
+    publicConfig.mode = mode;
+
+    // add public config to runtimeConfig — exposed to client and server.
+    // Nuxt automatically maps NUXT_PUBLIC_UMAMI_* env vars to these fields at runtime.
+    runtimeConfig.public.umami = publicConfig as unknown as typeof runtimeConfig.public.umami;
+
+    // add private config to runtimeConfig — server-only.
+    // Nuxt automatically maps NUXT_UMAMI_* env vars to these fields at runtime.
+    // Only meaningful in proxy: 'cloak' mode; empty strings otherwise.
     runtimeConfig.umami = privateConfig as unknown as typeof runtimeConfig.umami;
 
-    // generate utils template
+    // generate utils template — only contains collect() (tree-shaken per mode)
+    // and buildPathUrl() (urlOptions baked at build time). All config values are
+    // read from useRuntimeConfig() at call time inside the template functions.
     addTemplate({
       getContents: generateTemplate,
       filename: 'umami.config.mjs',
       write: true,
       options: {
         mode,
-        config: {
-          ...publicConfig,
-          logErrors: process.env.NODE_ENV === 'development' || logErrors,
-        },
         path: pathTo,
+        urlOptions: publicConfig.urlOptions,
+        logErrors: publicConfig.logErrors,
       },
     });
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,5 @@
 import type { ModuleOptions } from './options';
-import type { ModuleMode, NormalizedModuleOptions, UmPublicConfig } from './types';
+import type { ModuleMode, NormalizedModuleOptions, UmPrivateConfig, UmPublicConfig } from './types';
 import {
   addImports,
   addPlugin,
@@ -67,7 +67,7 @@ export default defineNuxtModule<ModuleOptions>({
       endpoint: '',
     } satisfies UmPublicConfig;
 
-    const privateConfig = { endpoint: '', website: '', domains };
+    const privateConfig: UmPrivateConfig = { endpoint: '', website: '', domains };
 
     let mode: ModuleMode = 'faux';
     const proxyOpts: Array<NormalizedModuleOptions['proxy']> = ['direct', 'cloak'];
@@ -120,7 +120,8 @@ export default defineNuxtModule<ModuleOptions>({
     }
 
     // add private config to runtime, only usable in server
-    runtimeConfig._proxyUmConfig = privateConfig;
+    // typed via UmPrivateConfig; accessed in server handler as useRuntimeConfig().umami
+    runtimeConfig.umami = privateConfig as unknown as typeof runtimeConfig.umami;
 
     // generate utils template
     addTemplate({

--- a/src/module.ts
+++ b/src/module.ts
@@ -18,7 +18,7 @@ export default defineNuxtModule<ModuleOptions>({
     version,
     configKey: 'umami',
     compatibility: {
-      nuxt: '>=3',
+      nuxt: '>=3.0.0',
     },
   },
   setup(options, nuxt) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -63,6 +63,13 @@ type ModuleOptions = Partial<{
    */
   useDirective: boolean;
   /**
+   * Collect Core Web Vitals (LCP, FCP, CLS, INP, TTFB) and report them to Umami.
+   * Requires Umami v3.1.0 or later.
+   *
+   * @default false
+   */
+  performance: boolean;
+  /**
    * Enable warning and error logs in production
    *
    * @default false

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -15,6 +15,7 @@ let configChecks: PreflightResult | undefined;
 let staticPayload: StaticPayload | undefined;
 let queryRef: string | undefined;
 let queryRefConsumed = false;
+let identifyId: string | undefined;
 
 function runPreflight(): PreflightResult {
   if (typeof window === 'undefined')
@@ -96,6 +97,9 @@ function getPayload(): ViewPayload {
   return {
     ...getStaticPayload(),
     ...(tag ? { tag } : null),
+    // Auto-include the distinct ID on all payloads after umIdentify is called,
+    // matching the behaviour of the official Umami tracker script.
+    ...(identifyId ? { id: identifyId } : null),
     url,
     title,
     referrer: ref,
@@ -175,16 +179,29 @@ function umTrackEvent(eventName: string, eventData?: EventData): FetchResult {
 }
 
 /**
- * Save data about the current session.
+ * Save data about the current session and optionally identify the user.
  *
- * Umami now supports saving session data, and
- * it works very similarly to custom event data.
+ * Supports three call signatures matching the official Umami tracker:
+ * - `umIdentify(uniqueId)` — set a distinct user ID (Umami v2.18.0+)
+ * - `umIdentify(uniqueId, sessionData)` — set ID and session data together
+ * - `umIdentify(sessionData)` — set session data only (original behaviour)
+ *
+ * The distinct ID is stored in a module-level closure and automatically
+ * included in all subsequent event and pageview payloads, matching the
+ * behaviour of the official Umami tracker script.
+ *
  * @see [v2.13.0 release](https://github.com/umami-software/umami/releases/tag/v2.13.0)
+ * @see [Umami Docs — Identify](https://umami.is/docs/tracker-functions)
  *
- * @param sessionData data for this session, provide an object in the format
- * `{key: value}`, where `key` = `string`, `value` = `string | number | boolean`.
+ * @param uniqueIdOrData distinct user ID string (max 50 chars) **or** session data object
+ * @param sessionData session data when first arg is a distinct ID
  */
-function umIdentify(sessionData?: EventData): FetchResult {
+function umIdentify(uniqueId: string, sessionData?: EventData): FetchResult;
+function umIdentify(sessionData?: EventData): FetchResult;
+function umIdentify(
+  uniqueIdOrData?: string | EventData,
+  sessionData?: EventData,
+): FetchResult {
   const check = runPreflight();
 
   if (check === 'ssr')
@@ -195,13 +212,30 @@ function umIdentify(sessionData?: EventData): FetchResult {
     return earlyPromise(false);
   }
 
-  const data = flattenObject(sessionData);
+  let id: string | undefined;
+  let data: ReturnType<typeof flattenObject>;
+
+  if (typeof uniqueIdOrData === 'string') {
+    // umIdentify(uniqueId) or umIdentify(uniqueId, sessionData)
+    id = uniqueIdOrData.trim().slice(0, 50) || undefined;
+    data = flattenObject(sessionData);
+  }
+  else {
+    // umIdentify(sessionData) — original behaviour
+    data = flattenObject(uniqueIdOrData ?? undefined);
+  }
+
+  // Persist the distinct ID so all subsequent tracking calls include it,
+  // matching the official Umami tracker script's identify() behaviour.
+  if (id)
+    identifyId = id;
 
   return collect({
     type: 'identify',
     payload: {
       ...getPayload(),
-      ...(data && { data }),
+      ...(id ? { id } : null),
+      ...(data ? { data } : null),
     } satisfies IdentifyPayload,
   });
 }

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -14,6 +14,7 @@ import { earlyPromise, flattenObject, isValidString } from './utils';
 let configChecks: PreflightResult | undefined;
 let staticPayload: StaticPayload | undefined;
 let queryRef: string | undefined;
+let queryRefConsumed = false;
 
 function runPreflight(): PreflightResult {
   if (typeof window === 'undefined')
@@ -65,13 +66,23 @@ function getStaticPayload(): StaticPayload {
 }
 
 function getQueryRef(): string {
-  if (typeof queryRef === 'string')
-    return queryRef;
+  // Only read and use the URL referral param once (on the landing page).
+  // After the first pageview is tracked, reset it so subsequent SPA
+  // navigations don't keep attributing all views to the original referrer.
+  if (queryRefConsumed)
+    return '';
 
-  const params = new URL(window.location.href).searchParams;
-  queryRef = params.get('referrer') || params.get('ref') || '';
+  if (typeof queryRef !== 'string') {
+    const params = new URL(window.location.href).searchParams;
+    queryRef = params.get('referrer') || params.get('ref') || '';
+  }
 
   return queryRef;
+}
+
+function consumeQueryRef(): void {
+  queryRefConsumed = true;
+  queryRef = '';
 }
 
 function getPayload(): ViewPayload {
@@ -111,7 +122,7 @@ function umTrackView(path?: string, referrer?: string): FetchResult {
 
   const url = buildPathUrl(isValidString(path) ? path : null);
 
-  return collect({
+  const result = collect({
     type: 'event',
     payload: {
       ...getPayload(),
@@ -119,6 +130,12 @@ function umTrackView(path?: string, referrer?: string): FetchResult {
       ...(isValidString(referrer) && { referrer }),
     } satisfies ViewPayload,
   });
+
+  // Consume the landing-page URL referral param after the first tracked view
+  // so subsequent SPA navigations don't keep attributing to the same referrer.
+  consumeQueryRef();
+
+  return result;
 }
 
 /**

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -167,6 +167,12 @@ function umTrackEvent(eventName: string, eventData?: EventData): FetchResult {
     logger('event-name');
     name = '#unknown-event';
   }
+  else if (eventName.length > 50) {
+    // Umami silently truncates names server-side; warn the developer and
+    // truncate here so what we log matches what Umami actually records.
+    logger('event-name-length');
+    name = eventName.slice(0, 50);
+  }
 
   return collect({
     type: 'event',

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -8,7 +8,9 @@ import type {
   StaticPayload,
   ViewPayload,
 } from '../types';
-import { buildPathUrl, collect, config, logger } from '#build/umami.config.mjs';
+import { buildPathUrl, collect } from '#build/umami.config.mjs';
+import { useRuntimeConfig } from '#imports';
+import { logger } from './logger';
 import { earlyPromise, flattenObject, isValidString } from './utils';
 
 let configChecks: PreflightResult | undefined;
@@ -29,7 +31,7 @@ function runPreflight(): PreflightResult {
     return configChecks;
 
   configChecks = (function (): PreflightResult {
-    const { ignoreLocalhost, domains } = config;
+    const { ignoreLocalhost, domains } = useRuntimeConfig().public.umami;
     const hostname = window.location.hostname;
 
     if (ignoreLocalhost && hostname === 'localhost')
@@ -54,7 +56,7 @@ function getStaticPayload(): StaticPayload {
     navigator: { language },
   } = window;
 
-  const { tag } = config;
+  const { tag } = useRuntimeConfig().public.umami;
 
   staticPayload = {
     hostname,

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -271,8 +271,8 @@ function umTrackRevenue(
 
   let $cur: string | null = null;
 
-  if (typeof currency === 'string' && /^[A-Z]{3}$/i.test(currency.trim()))
-    $cur = currency.trim();
+  if (typeof currency === 'string' && /^[A-Z]{3}$/.test(currency.trim().toUpperCase()))
+    $cur = currency.trim().toUpperCase();
   else
     logger('currency', `Got: ${currency}`);
 

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -4,6 +4,7 @@ import type {
   EventPayload,
   FetchResult,
   IdentifyPayload,
+  PerformancePayload,
   PreflightResult,
   StaticPayload,
   ViewPayload,
@@ -284,4 +285,107 @@ function umTrackRevenue(
   });
 }
 
-export { umIdentify, umTrackEvent, umTrackRevenue, umTrackView };
+function startPerformanceTracking(): () => void {
+  if (typeof window === 'undefined' || typeof PerformanceObserver === 'undefined')
+    return () => {};
+
+  if (runPreflight() !== true)
+    return () => {};
+
+  const t0 = performance.now();
+  let flushed = false;
+  const metrics = { ttfb: 0, fcp: 0, lcp: 0, cls: 0, inp: 0 };
+
+  // TTFB from Navigation Timing API
+  const [nav] = performance.getEntriesByType('navigation') as PerformanceNavigationTiming[];
+  if (nav) {
+    const activationStart = (nav as PerformanceNavigationTiming & { activationStart?: number }).activationStart ?? 0;
+    metrics.ttfb = Math.max(nav.responseStart - activationStart, 0);
+  }
+
+  const observers: PerformanceObserver[] = [];
+
+  function observe(type: string, cb: PerformanceObserverCallback, extra?: Record<string, unknown>) {
+    try {
+      const obs = new PerformanceObserver(cb);
+      obs.observe({ type, buffered: true, ...extra } as PerformanceObserverInit);
+      observers.push(obs);
+    }
+    catch { /* entry type unsupported in this browser */ }
+  }
+
+  observe('paint', (list) => {
+    const entry = list.getEntriesByName('first-contentful-paint')[0];
+    if (entry)
+      metrics.fcp = entry.startTime;
+  });
+
+  observe('largest-contentful-paint', (list) => {
+    const entries = list.getEntries();
+    if (entries.length)
+      metrics.lcp = entries.at(-1)!.startTime;
+  });
+
+  let clsSession = 0;
+  let clsSessionStart = -1;
+  observe('layout-shift', (list) => {
+    for (const e of list.getEntries() as (PerformanceEntry & { hadRecentInput: boolean; value: number })[]) {
+      if (e.hadRecentInput)
+        continue;
+      if (clsSessionStart >= 0 && e.startTime - clsSessionStart < 1000)
+        clsSession += e.value;
+      else
+        clsSession = e.value;
+      clsSessionStart = e.startTime;
+      if (clsSession > metrics.cls)
+        metrics.cls = clsSession;
+    }
+  });
+
+  observe('event', (list) => {
+    for (const e of list.getEntries()) {
+      if (e.duration > metrics.inp)
+        metrics.inp = e.duration;
+    }
+  }, { durationThreshold: 40 });
+
+  let timer: ReturnType<typeof setTimeout>;
+
+  function onHide() {
+    if (document.visibilityState === 'hidden')
+      flush();
+  }
+
+  function flush() {
+    if (flushed)
+      return;
+    flushed = true;
+    clearTimeout(timer);
+    document.removeEventListener('visibilitychange', onHide);
+    for (const obs of observers) {
+      try {
+        obs.disconnect();
+      }
+      catch {}
+    }
+
+    collect({
+      type: 'performance',
+      payload: {
+        ...getPayload(),
+        ttfb: metrics.ttfb,
+        fcp: metrics.fcp,
+        lcp: metrics.lcp,
+        cls: metrics.cls,
+        inp: metrics.inp,
+        duration: Math.round(performance.now() - t0),
+      } satisfies PerformancePayload,
+    });
+  }
+
+  timer = setTimeout(flush, 10_000);
+  document.addEventListener('visibilitychange', onHide);
+  return flush;
+}
+
+export { startPerformanceTracking, umIdentify, umTrackEvent, umTrackRevenue, umTrackView };

--- a/src/runtime/directive.ts
+++ b/src/runtime/directive.ts
@@ -1,6 +1,6 @@
 import type { Directive } from 'vue';
-import { logger } from '#build/umami.config.mjs';
 import { umTrackEvent } from './composables';
+import { logger } from './logger';
 
 // "savory" is a fun synonym for umami, why?
 // 1. dodge script blockers

--- a/src/runtime/logger.ts
+++ b/src/runtime/logger.ts
@@ -1,7 +1,7 @@
 import type { PreflightResult } from '../types';
 
 type PreflightErrId = Exclude<PreflightResult, 'ssr' | true>
-  | 'collect' | 'directive' | 'event-name' | 'endpoint' | 'id'
+  | 'collect' | 'directive' | 'event-name' | 'event-name-length' | 'endpoint' | 'id'
   | 'enabled' | 'currency' | 'revenue';
 type LogLevel = 'info' | 'warn' | 'error';
 interface ErrorObj {
@@ -19,6 +19,7 @@ const warnings: Record<PreflightErrId, ErrorObj> = {
   'collect': { level: 'error', text: 'Uhm... Something went wrong and I have no clue.' },
   'directive': { level: 'error', text: 'Invalid v-umami directive value. Expected string or object with {key:value} pairs. See https://umami.nuxt.dev/api/usage#directive' },
   'event-name': { level: 'warn', text: 'An Umami track event was fired without a name. `#unknown-event` will be used as event name.' },
+  'event-name-length': { level: 'warn', text: 'Umami event names are limited to 50 characters. The name will be truncated.' },
   'currency': { level: 'warn', text: 'Invalid currency passed. Expected ISO 4217 format. See https://en.wikipedia.org/wiki/ISO_4217#List_of_ISO_4217_currency_codes' },
   'revenue': { level: 'error', text: 'Revenue is not a number. Expected number, got: ' },
 };

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -12,22 +12,35 @@ export default defineNuxtPlugin({
     if (useDirective)
       nuxtApp.vueApp.directive('umami', directive);
     if (autoTrack) {
+      // Track the last path we fired a pageview for so that apps using nested
+      // <NuxtPage> components (which cause `page:finish` to fire multiple times
+      // per navigation) only record a single pageview per route change.
+      let lastTrackedPath: string | undefined;
+      let pendingTimer: ReturnType<typeof setTimeout> | undefined;
+
       nuxtApp.hook('page:finish', () => {
-        setTimeout(umTrackView, 250);
+        const currentPath = nuxtApp.$router.currentRoute.value.fullPath;
 
-        // TODO: fix
-        // `useHead()` updates the DOM's head using this hook
-        // currently, there is no hook we can watch, so we need
-        // to wait for the update to finish, to capture title
+        if (currentPath === lastTrackedPath)
+          return;
 
-        // TODO: update
-        // `page:loading:end` hook sounds like the fix for this,
-        // but the hook currently runs twice [bug: #26535]
+        // Debounce: if multiple `page:finish` events fire in rapid succession
+        // for the same navigation (e.g. nested layouts), only track once.
+        clearTimeout(pendingTimer);
+        pendingTimer = setTimeout(() => {
+          // Re-check in case another navigation started while we were waiting.
+          const path = nuxtApp.$router.currentRoute.value.fullPath;
+          if (path === lastTrackedPath)
+            return;
+          lastTrackedPath = path;
+          umTrackView();
 
-        // TODO: also
-        // injectHead().hooks.hook('dom:rendered', () => {})
-        // works flawlessly as long as the page is having its head
-        // rendered, if only there was a way to ALWAYS call that hook ;)
+          // NOTE: The setTimeout is a workaround for `useHead()` updating the
+          // page title asynchronously via the same `page:finish` hook. Without
+          // it we'd capture the previous page's title.
+          // `page:loading:end` would be cleaner but fired twice until Nuxt
+          // bug #26535 is resolved.
+        }, 250);
       });
     }
   },

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,14 +1,13 @@
-import { defineNuxtPlugin } from '#app';
-import { config } from '#build/umami.config.mjs';
+import { defineNuxtPlugin, useRouter, useRuntimeConfig } from '#app';
 import { umTrackView } from './composables';
 import { directive } from './directive';
-
-const { useDirective, autoTrack } = config;
 
 export default defineNuxtPlugin({
   name: 'umami-tracker',
   parallel: true,
   async setup(nuxtApp) {
+    const { useDirective, autoTrack } = useRuntimeConfig().public.umami;
+
     if (useDirective)
       nuxtApp.vueApp.directive('umami', directive);
     if (autoTrack) {
@@ -18,8 +17,10 @@ export default defineNuxtPlugin({
       let lastTrackedPath: string | undefined;
       let pendingTimer: ReturnType<typeof setTimeout> | undefined;
 
+      const router = useRouter();
+
       nuxtApp.hook('page:finish', () => {
-        const currentPath = nuxtApp.$router.currentRoute.value.fullPath;
+        const currentPath = router.currentRoute.value.fullPath;
 
         if (currentPath === lastTrackedPath)
           return;
@@ -29,7 +30,7 @@ export default defineNuxtPlugin({
         clearTimeout(pendingTimer);
         pendingTimer = setTimeout(() => {
           // Re-check in case another navigation started while we were waiting.
-          const path = nuxtApp.$router.currentRoute.value.fullPath;
+          const path = router.currentRoute.value.fullPath;
           if (path === lastTrackedPath)
             return;
           lastTrackedPath = path;

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,15 +1,19 @@
 import { defineNuxtPlugin, useRouter, useRuntimeConfig } from '#app';
-import { umTrackView } from './composables';
+import { startPerformanceTracking, umTrackView } from './composables';
 import { directive } from './directive';
 
 export default defineNuxtPlugin({
   name: 'umami-tracker',
   parallel: true,
   async setup(nuxtApp) {
-    const { useDirective, autoTrack } = useRuntimeConfig().public.umami;
+    const { useDirective, autoTrack, performance } = useRuntimeConfig().public.umami;
 
     if (useDirective)
       nuxtApp.vueApp.directive('umami', directive);
+
+    if (performance)
+      startPerformanceTracking();
+
     if (autoTrack) {
       // Track the last path we fired a pageview for so that apps using nested
       // <NuxtPage> components (which cause `page:finish` to fire multiple times

--- a/src/runtime/server/endpoint.ts
+++ b/src/runtime/server/endpoint.ts
@@ -21,7 +21,11 @@ export default defineEventHandler(async (event) => {
   }
 
   // grab config and host from runtimeConfig
-  const { endpoint, website, domains } = useRuntimeConfig()._proxyUmConfig;
+  const { endpoint, website, domains } = useRuntimeConfig().umami as {
+    endpoint: string;
+    website: string;
+    domains: string[] | null;
+  };
 
   // request headers
   const headers = getHeaders(event);

--- a/src/runtime/server/endpoint.ts
+++ b/src/runtime/server/endpoint.ts
@@ -31,6 +31,11 @@ export default defineEventHandler(async (event) => {
   const headers = getHeaders(event);
   const origin = headers.origin;
   const userAgent = headers['user-agent'];
+  // Forward the real client IP to Umami so geo-location works correctly
+  // when this proxy runs behind a CDN/edge network (Netlify, Vercel, etc.).
+  // Prefer the existing X-Forwarded-For chain; fall back to request-ip which
+  // handles X-Real-IP, CF-Connecting-IP, and other platform-specific headers.
+  const forwardedFor = headers['x-forwarded-for'] || getClientIp(event.node.req) || '';
 
   // TODO: option to limit access to only user domain, maybe use siteConfig
 
@@ -44,21 +49,21 @@ export default defineEventHandler(async (event) => {
 
   try {
     const { payload, cache, type } = result.output;
-    const ip = getClientIp(event.node.req);
 
     return await ofetch<string>(endpoint, {
       method: 'POST',
       headers: {
         ...(cache && { 'x-umami-cache': cache }),
         ...(userAgent && { 'user-agent': userAgent }),
+        // Pass the real client IP to Umami for accurate geo-location.
+        // Skip in dev (127.0.0.1 confuses Umami's IP parser).
+        ...(!import.meta.dev && forwardedFor && { 'x-forwarded-for': forwardedFor }),
       },
       body: {
         type,
         payload: {
           website,
           ...payload,
-          // don't send localhost ip (127.0.0.1)
-          ...(!import.meta.dev && { ip }),
         },
       },
       credentials: 'omit',

--- a/src/runtime/server/endpoint.ts
+++ b/src/runtime/server/endpoint.ts
@@ -13,7 +13,6 @@ export default defineEventHandler(async (event) => {
 
   // invalid data, throw error
   if (!result.success) {
-    console.log('[nuxt-umami-endpoint]: invalid data', result.output);
     throw createError({
       statusCode: 400,
       statusMessage: 'Invalid data.',

--- a/src/runtime/server/endpoint.ts
+++ b/src/runtime/server/endpoint.ts
@@ -19,12 +19,8 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  // grab config and host from runtimeConfig
-  const { endpoint, website, domains } = useRuntimeConfig().umami as {
-    endpoint: string;
-    website: string;
-    domains: string[] | null;
-  };
+  // grab config from runtimeConfig — fully typed via module augmentation in types.ts
+  const { endpoint, website, domains } = useRuntimeConfig().umami;
 
   // request headers
   const headers = getHeaders(event);

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -119,7 +119,7 @@ const validatorFns = {
 } as const;
 
 type PropertyValidator = keyof typeof validatorFns;
-type Payload = ViewPayload & EventPayload;
+type Payload = ViewPayload & EventPayload & { id?: string };
 
 const _payloadProps: Record<keyof Payload, PropertyValidator> = {
   hostname: 'nonempty',
@@ -131,6 +131,7 @@ const _payloadProps: Record<keyof Payload, PropertyValidator> = {
   tag: 'skip', // optional property
   name: 'skip', // optional, 'nonempty' in EventPayload
   data: 'skip', // optional, 'data' in EventPayload & IdentifyPayload
+  id: 'skip', // optional, distinct user ID in IdentifyPayload (Umami v2.18.0+)
 } as const;
 
 const _payloadType: PayloadTypes = ['event', 'identify'];
@@ -169,6 +170,12 @@ function isValidPayload(obj: object): obj is Payload {
   if (objKeys.includes('tag')) {
     validatorKeys.push('tag');
     validators.tag = 'string';
+  }
+
+  // optional distinct user ID (umIdentify with id, Umami v2.18.0+)
+  if (objKeys.includes('id')) {
+    validatorKeys.push('id');
+    validators.id = 'nonempty';
   }
 
   // check: all keys are present, no more, no less

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -207,11 +207,12 @@ function parseEventBody(body: unknown): ValidatePayloadReturn {
     output: body,
   } satisfies ValidatePayloadReturn;
 
-  // check: is record, no extra keys
-  if (!isRecord(body) || Object.keys(body).length !== _bodyProps.length)
+  // check: is record and all required top-level properties are present
+  // (intentionally not checking for extra keys so forward-compatible with
+  // future Umami API additions)
+  if (!isRecord(body))
     return error;
 
-  // check: top-level properties
   if (!(
     'type' in body && isValidString(body.type)
     && 'cache' in body && typeof body.cache === 'string'

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -4,6 +4,7 @@ import type {
   FetchResult,
   NormalizedModuleOptions,
   PayloadTypes,
+  PerformancePayload,
   ServerPayload,
   ViewPayload,
 } from '../types';
@@ -38,6 +39,7 @@ function normalizeConfig(options: ModuleOptions = {}): NormalizedModuleOptions {
     useDirective = false,
     logErrors = false,
     enabled = true,
+    performance = false,
     tag = undefined,
     excludeQueryParams = false,
     trailingSlash = 'any',
@@ -82,6 +84,7 @@ function normalizeConfig(options: ModuleOptions = {}): NormalizedModuleOptions {
     autoTrack: autoTrack !== false,
     useDirective: useDirective === true,
     logErrors: logErrors === true,
+    performance: performance === true,
     enabled: enabled !== false,
   };
 }
@@ -134,7 +137,7 @@ const _payloadProps: Record<keyof Payload, PropertyValidator> = {
   id: 'skip', // optional, distinct user ID in IdentifyPayload (Umami v2.18.0+)
 } as const;
 
-const _payloadType: PayloadTypes = ['event', 'identify'];
+const _payloadType: PayloadTypes = ['event', 'identify', 'performance'];
 const _bodyProps: Array<keyof ServerPayload> = ['cache', 'payload', 'type'];
 
 function isValidPayload(obj: object): obj is Payload {
@@ -197,6 +200,19 @@ function isValidPayload(obj: object): obj is Payload {
   return true;
 }
 
+const _perfNumericKeys = ['ttfb', 'fcp', 'lcp', 'cls', 'inp', 'duration'] as const;
+
+function isValidPerformancePayload(obj: object): obj is PerformancePayload {
+  if (!isRecord(obj))
+    return false;
+  const required: string[] = ['hostname', 'language', 'screen', 'url', ..._perfNumericKeys];
+  return (
+    required.every(k => k in obj)
+    && _perfNumericKeys.every(k => typeof (obj as Record<string, unknown>)[k] === 'number')
+    && isValidString((obj as Record<string, unknown>).hostname)
+  );
+}
+
 type ValidatePayloadReturn =
   | { success: true; output: ServerPayload }
   | { success: false; output: unknown };
@@ -226,7 +242,12 @@ function parseEventBody(body: unknown): ValidatePayloadReturn {
   if (!includes(_payloadType, type))
     return error;
 
-  // check: body.payload is valid
+  if (type === 'performance') {
+    if (!isValidPerformancePayload(payload))
+      return error;
+    return { success: true, output: { type, cache, payload } };
+  }
+
   if (!isValidPayload(payload))
     return error;
 

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,18 +1,22 @@
-import type { ModuleMode, UmPublicConfig } from './types';
+import type { ModuleMode, NormalizedModuleOptions } from './types';
 
 interface TemplateOptions {
   options: {
     mode: ModuleMode;
-    config: UmPublicConfig & { logErrors: boolean };
     path: {
       utils: string;
       types: string;
       logger: string;
     };
+    urlOptions: Required<Required<NormalizedModuleOptions>['urlOptions']>;
+    logErrors: boolean;
   };
 };
 
-const fn_faux = `const payload = load.payload;
+// In faux mode: log config errors and bail out immediately.
+// Reads enabled/endpoint/website from runtimeConfig at call time.
+const fn_faux = `const { enabled, endpoint, website } = useRuntimeConfig().public.umami;
+  const payload = load.payload;
 
   if (enabled) {
     if (!endpoint)
@@ -26,6 +30,7 @@ const fn_faux = `const payload = load.payload;
   logger('enabled');
   return Promise.resolve({ ok: true });`;
 
+// In proxy (cloak) mode: forward to /api/savory (server handler reads real endpoint from private runtimeConfig).
 const fn_proxy = `return ofetch('/api/savory', {
     method: 'POST',
     body: { ...load, cache },
@@ -33,7 +38,9 @@ const fn_proxy = `return ofetch('/api/savory', {
     .then(handleSuccess)
     .catch(handleError);`;
 
+// In direct mode: read endpoint/website from public runtimeConfig at call time.
 const fn_direct = `const { type, payload } = load;
+  const { endpoint, website } = useRuntimeConfig().public.umami;
 
   return ofetch(endpoint, {
     method: 'POST',
@@ -47,28 +54,19 @@ const fn_direct = `const { type, payload } = load;
 const collectFn: Record<`fn_${ModuleMode}`, string> = { fn_direct, fn_faux, fn_proxy };
 
 function generateTemplate({
-  options: { mode, path, config: { logErrors, ...config } },
+  options: { mode, path, urlOptions, logErrors },
 }: TemplateOptions) {
   return `// template-generated
 import { ofetch } from 'ofetch';
-import { ${logErrors ? 'logger' : 'fauxLogger'} as $logger } from "${path.logger}";
+import { useRuntimeConfig } from '#imports';
+import { ${logErrors ? 'logger' : 'fauxLogger'} as logger } from "${path.logger}";
 
 /**
  * @typedef {import("${path.types}").FetchFn} FetchFn
  * 
  * @typedef {import("${path.types}").BuildPathUrlFn} BuildPathUrlFn
- * 
- * @typedef {import("${path.types}").UmPublicConfig} UmPublicConfig
  */
 
-export const logger = $logger;
-
-/**
- * @type UmPublicConfig
-*/
-export const config = ${JSON.stringify(config, null, 2)};
-
-const { endpoint, website, enabled } = config;
 let cache = '';
 
 function handleError(err) {
@@ -100,12 +98,12 @@ export function buildPathUrl(loc) {
     const url = new URL(loc, window.location.href);
     const path = url.pathname;
   
-    ${config.urlOptions.excludeHash && `url.hash = '';`}
-    ${config.urlOptions.excludeSearch && `url.search = '';`}
+    ${urlOptions.excludeHash && `url.hash = '';`}
+    ${urlOptions.excludeSearch && `url.search = '';`}
   
-    url.pathname = ${config.urlOptions.trailingSlash === 'always'
+    url.pathname = ${urlOptions.trailingSlash === 'always'
       ? `path.endsWith('/') ? path : path + '/'`
-      : config.urlOptions.trailingSlash === 'never'
+      : urlOptions.trailingSlash === 'never'
         ? `path.endsWith('/') ? path.slice(0, -1) : path`
         : `path`};
   

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,8 +74,8 @@ type FetchResult = Promise<{ ok: boolean }>;
 type FetchFn = (load: ServerPayload) => FetchResult;
 type BuildPathUrlFn = (loc: string | null) => string;
 
-type _Letter = `${'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H'
-  | 'I' | 'J' | 'K' | 'M' | 'L' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S'
+type _Letter = `${'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I'
+  | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S'
   | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z'}`;
 
 type CurrencyCode = Uppercase<`${_Letter}${_Letter}${_Letter}`>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,8 @@ interface StaticPayload {
   language: string;
   hostname: string;
   tag?: string;
+  /** Distinct user ID set via umIdentify(). Auto-included in all payloads. */
+  id?: string;
 }
 
 interface ViewPayload extends StaticPayload {
@@ -56,6 +58,8 @@ interface EventPayload extends ViewPayload {
 };
 
 interface IdentifyPayload extends ViewPayload {
+  /** Distinct user ID (max 50 chars). Added in Umami v2.18.0. */
+  id?: string;
   data?: Record<string, unknown>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ interface UmPublicConfig extends _PublicConfig {
 interface UmPrivateConfig {
   website: string;
   endpoint: string;
+  domains: Array<string> | null;
 }
 
 type PreflightResult = true | 'ssr' | 'domain' | 'localhost' | 'local-storage';

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,9 @@ type _PublicConfig = Omit<
 interface UmPublicConfig extends _PublicConfig {
   website: string;
   endpoint: string;
+  /** Determines which collect() implementation to use at runtime */
+  mode: ModuleMode;
+  logErrors: boolean;
 }
 
 interface UmPrivateConfig {
@@ -83,6 +86,15 @@ type CurrencyCode = Uppercase<`${_Letter}${_Letter}${_Letter}`>;
 type Prettify<T> = {
   [K in keyof T]: T[K];
 } & {};
+
+declare module 'nuxt/schema' {
+  interface PublicRuntimeConfig {
+    umami: UmPublicConfig;
+  }
+  interface RuntimeConfig {
+    umami: UmPrivateConfig;
+  }
+}
 
 export type {
   BuildPathUrlFn,

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ type ModuleMode = 'faux' | 'proxy' | 'direct';
 
 type EventData = Record<string, string | number | boolean> | null;
 
-type PayloadTypes = ['event', 'identify'];
+type PayloadTypes = ['event', 'identify', 'performance'];
 
 interface StaticPayload {
   screen: string;
@@ -67,10 +67,19 @@ interface IdentifyPayload extends ViewPayload {
   data?: Record<string, unknown>;
 }
 
+interface PerformancePayload extends ViewPayload {
+  ttfb: number;
+  fcp: number;
+  lcp: number;
+  cls: number;
+  inp: number;
+  duration: number;
+}
+
 interface ServerPayload {
   cache?: string;
   type: PayloadTypes[number];
-  payload: ViewPayload | EventPayload;
+  payload: ViewPayload | EventPayload | PerformancePayload;
 };
 
 type FetchResult = Promise<{ ok: boolean }>;
@@ -107,6 +116,7 @@ export type {
   ModuleMode,
   NormalizedModuleOptions,
   PayloadTypes,
+  PerformancePayload,
   PreflightResult,
   ServerPayload,
   StaticPayload,


### PR DESCRIPTION
Adds a `performance` option to the module that collects Core Web Vitals
and reports them to Umami — the equivalent of the `data-performance="true"`
attribute on the official Umami script tag.

Since `nuxt-umami` doesn't inject a `<script>` tag but instead uses composables
and direct API calls, the `data-performance` attribute has no effect here.
This PR implements the same functionality natively.

---

### What's new

- `performance: boolean` option in `nuxt.config.ts` (requires Umami ≥ v3.1.0)
- Collects all 5 Core Web Vitals: **LCP**, **FCP**, **CLS**, **INP**, **TTFB**
- Flushes metrics after 10 seconds or when the page becomes hidden
  (`visibilitychange`) — matching the official tracker's behaviour
- Works in all proxy modes, including `proxy: 'cloak'` (server-side validation
  extended to handle `type: 'performance'` payloads)

### Usage

```ts
// nuxt.config.ts
umami: {
  host: 'https://your-umami.com',
  id: 'your-website-id',
  performance: true,
}
```

### Implementation notes

- TTFB via Navigation Timing API (`responseStart - activationStart)
- FCP via `PerformanceObserver('paint')`
- LCP via `PerformanceObserver('largest-contentful-paint')`
- CLS via session-window algorithm (< 1s gaps between shifts)
- INP via `PerformanceObserver('event', { durationThreshold: 40 })`
- All observers use `buffered: true` to capture entries fired before registration (important for SSR hydration)
- Unsupported entry types in older browsers are silently ignored via `try/catch`